### PR TITLE
make Makefile work with other compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXX=g++
+CXX=c++
 SOURCES=bf2c.cpp
 CXXFLAGS=-O3
 EXECUTABLE=bf2c


### PR DESCRIPTION
Out of the box, Makefile won't work with system's which dont have g++. But with this, it works on systems which have a C++ compiler.